### PR TITLE
Fixed isValidUser username and password check

### DIFF
--- a/backend/fx-data-provider.js
+++ b/backend/fx-data-provider.js
@@ -5,7 +5,7 @@ var ds = deepstreamClient( 'localhost:6022' );
 var priceGenerator = new PriceGenerator();
 
 priceGenerator.on( 'ready', function() {
-	ds.login( { username: 'fx-provider' }, listenForSubscriptions );
+	ds.login( { username: 'fx-provider', password: 'complicatedProviderPassword' }, listenForSubscriptions );
 } );
 
 function listenForSubscriptions() {

--- a/backend/permission-handler.js
+++ b/backend/permission-handler.js
@@ -16,8 +16,8 @@ PermissionHandler.prototype.isValidUser = function( connectionData, authData, ca
 	/**
 	 * If username matches that of a provider authenticate against provided password
 	 */
-	if( this.isProvider( authData.username &&
-			authData.password !== 'complicatedProviderPassword' ) ) {
+	if( this.isProvider( authData.username ) &&
+			authData.password !== 'complicatedProviderPassword' ) {
 		callback( 'Invalid credentials.' );
 	}
 	/**


### PR DESCRIPTION
When checking data provider credentials in `isValidUser`, it always passes `true` to isProvider. For data providers we may want to check both username and password.
